### PR TITLE
Minor fixes

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,7 +5,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>React Starter</title>
+  <title>Trailblazers Reviews</title>
 </head>
 
 <body>

--- a/server/app.js
+++ b/server/app.js
@@ -16,10 +16,13 @@ app.use((req, res, next) => {
 app.use(express.static(`${__dirname}./../client/dist`));
 
 app.get('/product/:productId', (req, res) => {
-  const options = { headers: { 'Content-Type': 'text/html' } };
-  const file = path.join(`${__dirname}./../client/public/index.html`);
-
-  res.sendFile(file, options);
+  if (req.params.productId === 'random') {
+    res.redirect(`/product/${Math.floor(Math.random() * 100) + 1}`);
+  } else {
+    const options = { headers: { 'Content-Type': 'text/html' } };
+    const file = path.join(`${__dirname}./../client/public/index.html`);
+    res.sendFile(file, options);
+  }
 });
 
 app.get('/reviews/:productId', (req, res) => {

--- a/server/app.test.js
+++ b/server/app.test.js
@@ -33,6 +33,11 @@ describe('/reviews endpoint', () => {
         done();
       });
   });
+  it('should redirect for /product/random', () => {
+    request(app)
+      .get('/product/random')
+      .then(res => expect(res.statusCode).to.equal(302));
+  });
   it('should return 400 when the productId is malformed', done => {
     request(app)
       .get('/reviews/banana')


### PR DESCRIPTION
This PR adds a `/product/random endpoint`, with tests

The /product/random endpoint redirect to a random product.  This could
be useful in production if we want to have a random product feature.
More importantly right now, it's helpful for manual testing to be able
to see many product pages quickly.

The PR also changes the title (displayed in the browser) from "React Starter" to "Trailblazers Reviews"